### PR TITLE
Rework find command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,28 +1,44 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.EmailIsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneIsKeywordPredicate;
+
+import java.util.function.Predicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and displays the person whose unique identifier is exactly the same as the specified keyword.<br>
+ * Currently, the unique identifiers supported are:
+ * <ul>
+ *     <li>Email</li>
+ *     <li>Phone number</li>
+ * </ul>
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds a person based on his/her unique identifier "
+            + "and displays the person's full information.\n"
+            + "Unique identifiers are email address and phone number.\n"
+            + "Because this looks for the exact person, the exact phone number or email must be specified.\n"
+            + "Only supply exactly ONE attribute for finding.\n"
+            + "Parameters: [" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_PHONE + "91234578\n"
+            + "or: " + COMMAND_WORD + " " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -28,13 +28,17 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds a person based on his/her unique identifier "
             + "and displays the person's full information.\n"
-            + "Unique identifiers are email address and phone number.\n"
+            + "Unique identifiers currently contain email address and phone number.\n"
             + "Because this looks for the exact person, the exact phone number or email must be specified.\n"
-            + "Only supply exactly ONE attribute for finding.\n"
+            + "NOTE: Only supply exactly ONE attribute for finding.\n"
             + "Parameters: [" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_PHONE + "91234578\n"
             + "or: " + COMMAND_WORD + " " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com";
+
+    public static final String TOO_MANY_IDENTIFIERS_SPECIFIED = "Too many attributes specified!\n%1$s";
+    public static final String NOT_UNIQUE_ATTRIBUTE_DETECTED = "A non-unique attribute detected!\n"
+            + "For non-unique attributes, use 'filter'.\n%1$s";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,11 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Returns the number of detected prefixes in the argument multimap.
+     */
+    public int getNumberOfPrefixes() {
+        return argMultimap.size();
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -25,6 +26,9 @@ public class ArgumentTokenizer {
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
+        for (PrefixPosition pp : positions) {
+            System.out.println(">> " + pp);
+        }
         return extractArguments(argsString, positions);
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,16 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
-import java.util.Arrays;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.EmailIsKeywordPredicate;
+import seedu.address.model.person.PhoneIsKeywordPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -20,14 +24,37 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
+
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        if (argMultimap.getNumberOfPrefixes() > 2) {
+            throw new ParseException(
+                    String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()
+                || argMultimap.getValue(PREFIX_ADDRESS).isPresent()
+                || argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            throw new ParseException(
+                    String.format(FindCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, FindCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            return new FindCommand(new PhoneIsKeywordPredicate(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            return new FindCommand(new EmailIsKeywordPredicate(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+
+        throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/EmailIsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailIsKeywordPredicate.java
@@ -1,0 +1,41 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Email} <b>exactly</b> matches the email given.
+ */
+public class EmailIsKeywordPredicate implements Predicate<Person> {
+    private final String emailKeyword;
+
+    public EmailIsKeywordPredicate(String emailKeyword) {
+        this.emailKeyword = emailKeyword;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getEmail().value.equals(emailKeyword);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EmailIsKeywordPredicate)) {
+            return false;
+        }
+
+        EmailIsKeywordPredicate otherEmailIsKeywordPredicate = (EmailIsKeywordPredicate) other;
+        return this.emailKeyword.equals(otherEmailIsKeywordPredicate.emailKeyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("email", emailKeyword).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/PhoneIsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneIsKeywordPredicate.java
@@ -1,0 +1,40 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} <b>exactly</b> matches the phone given.
+ */
+public class PhoneIsKeywordPredicate implements Predicate<Person> {
+    private final String phoneKeyword;
+
+    public PhoneIsKeywordPredicate(String phoneKeyword) {
+        this.phoneKeyword = phoneKeyword;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getPhone().value.equals(phoneKeyword);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PhoneIsKeywordPredicate otherPhoneIsKeywordPredicate)) {
+            return false;
+        }
+
+        return this.phoneKeyword.equals(otherPhoneIsKeywordPredicate.phoneKeyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("phone", phoneKeyword).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,7 +14,9 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.EmailIsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneIsKeywordPredicate;
 
 public class FindCommandParserTest {
 
@@ -17,18 +24,74 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser,
+                "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
-
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    public void parse_onlyFindArg_throwsParseException() {
+        assertParseFailure(parser,
+                "find ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
+    @Test
+    public void parse_argMoreThanOneAttribute_throwsParseException() {
+        assertParseFailure(parser,
+                String.format("find %s91237483 %silovecraftconnect@gmail.com", PREFIX_PHONE, PREFIX_EMAIL),
+                String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser,
+                String.format("find %sneil deGrease Tyson %sastrophysicist@nasa.gov %steacher",
+                        PREFIX_NAME, PREFIX_EMAIL, PREFIX_TAG),
+                String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser,
+                String.format("find %scolleagues %s59 Dummy Street, Gotham %s83582957 %sfriend",
+                        PREFIX_TAG, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_TAG),
+                String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_argContainsName_throwsParseExceptionForNonUniqueAttribute() {
+        assertParseFailure(parser,
+                "find " + PREFIX_NAME + "alex yeoh",
+                String.format(FindCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_argContainsAddress_throwsParseExceptionForNonUniqueAttribute() {
+        assertParseFailure(parser,
+                "find " + PREFIX_ADDRESS + "420 Craft Avenue, Singapore 572847",
+                String.format(FindCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, FindCommand.MESSAGE_USAGE));
+    }
+
+    // integration test
+    @Test
+    public void parse_emailArg_returnsFindCommand() {
+        // no whitespace
+        FindCommand expectedFindCommand =
+                new FindCommand(new EmailIsKeywordPredicate("ilovecraftconnect@gmail.com"));
+        assertParseSuccess(parser, "find " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com", expectedFindCommand);
+
+        // trailing whitespace
+        expectedFindCommand =
+                new FindCommand(new EmailIsKeywordPredicate("ilovecraftconnect@gmail.com"));
+        assertParseSuccess(parser, "  find    " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_phoneArg_returnsFindCommand() {
+        // no whitespace
+        FindCommand expectedFindCommand =
+                new FindCommand(new PhoneIsKeywordPredicate("93424353"));
+        assertParseSuccess(parser, "find " + PREFIX_PHONE + "93424353", expectedFindCommand);
+
+
+        // trailing whitespace
+        expectedFindCommand =
+                new FindCommand(new PhoneIsKeywordPredicate("93424353"));
+        assertParseSuccess(parser, " find  " + PREFIX_PHONE + "93424353", expectedFindCommand);
+    }
 }

--- a/src/test/java/seedu/address/model/person/EmailIsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmailIsKeywordPredicateTest.java
@@ -1,0 +1,91 @@
+package seedu.address.model.person;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.testutil.PersonBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmailIsKeywordPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstEmailKeyword = "ilovecraftconnect@gmail.com";
+        String secondEmailKeyword = "e1234567@u.nus.edu";
+
+        EmailIsKeywordPredicate firstEmailPredicate = new EmailIsKeywordPredicate(firstEmailKeyword);
+        EmailIsKeywordPredicate secondEmailPredicate = new EmailIsKeywordPredicate(secondEmailKeyword);
+
+        // same object -> returns true
+        assertEquals(firstEmailPredicate, firstEmailPredicate);
+
+        // same values -> returns true
+        EmailIsKeywordPredicate firstEmailPredicateCopy = new EmailIsKeywordPredicate(firstEmailKeyword);
+        assertEquals(firstEmailPredicate, firstEmailPredicateCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, firstEmailPredicate);
+
+        // null -> returns false
+        assertNotEquals(null, firstEmailPredicate);
+
+        // different person -> returns false
+        assertNotEquals(firstEmailPredicate, secondEmailPredicate);
+    }
+
+    @Test
+    public void test_emailIsKeyword_returnsTrue() {
+        String firstEmailKeyword = "ilovecraftconnect@gmail.com";
+        EmailIsKeywordPredicate firstEmailPredicate = new EmailIsKeywordPredicate(firstEmailKeyword);
+
+        String secondEmailKeyword = "e1234567@u.nus.edu";
+        EmailIsKeywordPredicate secondEmailPredicate = new EmailIsKeywordPredicate(secondEmailKeyword);
+
+        assertTrue(firstEmailPredicate.test(new PersonBuilder().withEmail(firstEmailKeyword).build()));
+        assertTrue(firstEmailPredicate.test(new PersonBuilder().withEmail("ilovecraftconnect@gmail.com").build()));
+
+        assertTrue(secondEmailPredicate.test(new PersonBuilder().withEmail(secondEmailKeyword).build()));
+        assertTrue(secondEmailPredicate.test(new PersonBuilder().withEmail("e1234567@u.nus.edu").build()));
+    }
+
+    @Test
+    public void test_emailIsNotKeyword_returnsFalse() {
+        String firstEmailKeyword = "ilovecraftconnect@gmail.com";
+        EmailIsKeywordPredicate firstEmailPredicate = new EmailIsKeywordPredicate(firstEmailKeyword);
+
+        String secondEmailKeyword = "e1234567@u.nus.edu";
+        EmailIsKeywordPredicate secondEmailPredicate = new EmailIsKeywordPredicate(secondEmailKeyword);
+
+        // unmatched keyword
+        assertFalse(firstEmailPredicate.test(new PersonBuilder().withEmail(secondEmailKeyword).build()));
+        assertFalse(firstEmailPredicate.test(new PersonBuilder().withEmail("e1234567@u.nus.edu").build()));
+        assertFalse(firstEmailPredicate.test(new PersonBuilder().withEmail("craftconect@gmail.com").build()));
+
+        assertFalse(secondEmailPredicate.test(new PersonBuilder().withEmail(firstEmailKeyword).build()));
+        assertFalse(secondEmailPredicate.test(new PersonBuilder().withEmail("ilovecraftconnect@gmail.com").build()));
+        assertFalse(secondEmailPredicate.test(new PersonBuilder().withEmail("1234567@u.nus.edu").build()));
+
+        // null email string
+        EmailIsKeywordPredicate nullEmailPredicate = new EmailIsKeywordPredicate(null);
+        assertFalse(nullEmailPredicate.test(new PersonBuilder().withEmail("e1234567@u.nus.edu").build()));
+
+        // empty email string
+        EmailIsKeywordPredicate emptyEmailPredicate = new EmailIsKeywordPredicate("");
+        assertFalse(emptyEmailPredicate.test(new PersonBuilder().withEmail("e1234567@u.nus.edu").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String email = "ilovecraftconnect@gmail.com";
+        EmailIsKeywordPredicate predicate = new EmailIsKeywordPredicate(email);
+
+        String expected = EmailIsKeywordPredicate.class.getCanonicalName() + "{email=" + email + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/PhoneIsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneIsKeywordPredicateTest.java
@@ -1,0 +1,84 @@
+package seedu.address.model.person;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.testutil.PersonBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PhoneIsKeywordPredicateTest {
+    @Test
+    public void equals() {
+        String firstPhone = "93424353";
+        String secondPhone = "0910671358";
+
+        PhoneIsKeywordPredicate firstPhonePredicate = new PhoneIsKeywordPredicate(firstPhone);
+        PhoneIsKeywordPredicate secondPhonePredicate = new PhoneIsKeywordPredicate(secondPhone);
+
+        // same object -> returns true
+        assertEquals(firstPhonePredicate, firstPhonePredicate);
+
+        // same values -> returns true
+        PhoneIsKeywordPredicate firstPhonePredicateCopy = new PhoneIsKeywordPredicate(firstPhone);
+        assertEquals(firstPhonePredicate, firstPhonePredicateCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, firstPhonePredicate);
+
+        // null -> returns false
+        assertNotEquals(null, firstPhonePredicate);
+
+        // different person -> returns false
+        assertNotEquals(firstPhonePredicate, secondPhonePredicate);
+    }
+
+    @Test
+    public void test_phoneIsKeyword_returnsTrue() {
+        String firstPhone = "93424353";
+        String secondPhone = "0910671358";
+
+        PhoneIsKeywordPredicate firstPhonePredicate = new PhoneIsKeywordPredicate(firstPhone);
+        PhoneIsKeywordPredicate secondPhonePredicate = new PhoneIsKeywordPredicate(secondPhone);
+
+        assertTrue(firstPhonePredicate.test(new PersonBuilder().withPhone(firstPhone).build()));
+        assertTrue(firstPhonePredicate.test(new PersonBuilder().withPhone("93424353").build()));
+
+        assertTrue(secondPhonePredicate.test(new PersonBuilder().withPhone(secondPhone).build()));
+        assertTrue(secondPhonePredicate.test(new PersonBuilder().withPhone("0910671358").build()));
+    }
+
+    @Test
+    public void test_phoneIsNotKeyword_returnsFalse() {
+        String firstPhone = "93424353";
+        String secondPhone = "0910671358";
+
+        PhoneIsKeywordPredicate firstPhonePredicate = new PhoneIsKeywordPredicate(firstPhone);
+        PhoneIsKeywordPredicate secondPhonePredicate = new PhoneIsKeywordPredicate(secondPhone);
+
+        // unmatched keyword
+        assertFalse(firstPhonePredicate.test(new PersonBuilder().withPhone(secondPhone).build()));
+        assertFalse(firstPhonePredicate.test(new PersonBuilder().withPhone("0912345678").build()));
+
+        assertFalse(secondPhonePredicate.test(new PersonBuilder().withPhone(firstPhone).build()));
+        assertFalse(secondPhonePredicate.test(new PersonBuilder().withPhone("91238172").build()));
+
+        // null phone string
+        PhoneIsKeywordPredicate nullPhonePredicate = new PhoneIsKeywordPredicate(null);
+        assertFalse(nullPhonePredicate.test(new PersonBuilder().withPhone("91238172").build()));
+
+        // empty phone string
+        PhoneIsKeywordPredicate emptyPhonePredicate = new PhoneIsKeywordPredicate("");
+        assertFalse(emptyPhonePredicate.test(new PersonBuilder().withPhone("0123847684").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String phone = "85630193";
+        PhoneIsKeywordPredicate predicate = new PhoneIsKeywordPredicate(phone);
+
+        String expected = PhoneIsKeywordPredicate.class.getCanonicalName() + "{phone=" + phone + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
The find command has changed from find by name to find by unique identifier (email and phone).

- Previously, `FindCommand` takes in a `NameHasKeywordsPredicate` (which implements `Predicate<Person>`) to check for matching names. Now,` FindCommand` takes in a `Predicate<Person>` in general to allow more checks on a `Person`. 
- Since we need to check for email and phone number, two more classes, `EmailIsKeywordPredicate` and `PhoneIsKeywordPredicate` (which implement `Predicate<Person>`), are added. These classes check for exact matching email addresses and phone number respectively.
- `FindCommandParser` now handles the following cases (in the listed order). All errors thrown below are `ParseException`:
  - If no supported argument (`find`), throws an invalid command error message.
  - If more than one argument (`find p\12345678 e\dummy@example.com`), throws a too-many-attributes error message. Also, ArgumentMultimap has another method to return the number of prefix-argument pairs detected.
  - If a non-unique attribute is specified (`find n\john smith`), throws a non-unique attribute message.
  - If the attribute checked is phone number (`find p\12345678`), return a FindCommand with PhoneIsKeywordPredicate.
  - If the attribute checked is email address (`find e\dummy@example.com`), return a FindCommand with EmailIsKeywordPredicate.
  - Else (`find some random word`), throws an invalid command error message.