### PR TITLE
Rework delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,15 +1,22 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.EmailIsKeywordPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.PhoneIsKeywordPredicate;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -19,16 +26,78 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the person identified by his/her unique identifier.\n"
+            + "Currently, unique identifiers include email, phone number and index.\n"
+            + "- Deletion by index is based on the currently filtered model. "
+            + "For instance, suppose after a call to 'find' or 'filter', person A is displayed with index 1. "
+            + "Deletion by index 1 will remove A.\n"
+            + "- Deletion by email or phone number is regardless of what filter is applied and what is displayed. "
+            + "For example, suppose after a call to 'find' or 'filter', person A is not displayed. "
+            + "Deletion by person A's email or phone number is still allowed.\n"
+            + "NOTE: Only supply exactly ONE attribute for deletion.\n"
+            + "Parameters: [INDEX] (must be a positive integer) ["
+            + PREFIX_PHONE + "PHONE_NUMBER] ["
+            + PREFIX_EMAIL + "EMAIL]\n"
+            + "Example: " + COMMAND_WORD + " 1\n"
+            + "or: " + COMMAND_WORD + " " + PREFIX_PHONE + "98761234\n"
+            + "or: " + COMMAND_WORD + " " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String TOO_MANY_ATTRIBUTES_SPECIFIED = "Too many attributes specified!\n%1$s";
+    public static final String NOT_UNIQUE_ATTRIBUTE_DETECTED = "A non-unique attribute is detected!\n%1s";
+    public static final String NO_PERSON_WITH_MATCHING_EMAIL = "No person with matching email address.";
+    public static final String NO_PERSON_WITH_MATCHING_PHONE = "No person with matching phone number.";
 
-    private final Index targetIndex;
+    private enum DeletionType {
+        BY_INDEX, BY_EMAIL, BY_PHONE
+    }
 
+    private final Object target;
+    private final DeletionType deletionAttribute;
+
+    /**
+     * Initialises a DeleteCommand with a target index.
+     * @param targetIndex The index of the person to delete.
+     */
     public DeleteCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+        this.target = targetIndex;
+        this.deletionAttribute = DeletionType.BY_INDEX;
+    }
+
+    /**
+     * Initialises a DeleteCommand with a target email address.
+     * @param email The email address of the person to delete.
+     */
+    public DeleteCommand(Email email) {
+        this.target = email;
+        this.deletionAttribute = DeletionType.BY_EMAIL;
+    }
+
+    /**
+     * Initialises a DeleteCommand with a target phone number.
+     * @param phone The phone number of the person to delete.
+     */
+    public DeleteCommand(Phone phone) {
+        this.target = phone;
+        this.deletionAttribute = DeletionType.BY_PHONE;
+    }
+
+    /**
+     * Returns the first person whose information matches the given predicate.<br>
+     * Ideally, this is used for searching a unique person, so the supplied predicate should
+     * be related to a person's unique attribute, such as phone number and email address.
+     *
+     * @param people The list of Person
+     * @param predicate The predicate that acts on a Person object
+     * @return The first person whose information matches the predicate.
+     */
+    private Person find(List<Person> people, Predicate<Person> predicate) {
+        for (Person person : people) {
+            if (predicate.test(person)) {
+                return person;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -36,13 +105,54 @@ public class DeleteCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        switch (this.deletionAttribute) {
+        case BY_INDEX -> {
+            Index targetIndex = (Index) target;
+
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+
+            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+            model.deletePerson(personToDelete);
+            return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        }
+        case BY_EMAIL -> {
+            // deletion by email works even if the filtered list does not have the matching email
+            // because each email is uniquely bounded to one person
+            // thus, restore the unfiltered address book before checking email existence
+            model.updateFilteredPersonList(person -> true);
+            Email targetEmail = (Email) target;
+            Person personToDelete = find(lastShownList, new EmailIsKeywordPredicate(targetEmail.value));
+
+            if (personToDelete == null) {
+                throw new CommandException(DeleteCommand.NO_PERSON_WITH_MATCHING_EMAIL);
+            }
+
+            model.deletePerson(personToDelete);
+            return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        }
+        case BY_PHONE -> {
+            // deletion by phone number works even if the filtered list does not have the matching phone number
+            // because each phone number is uniquely bounded to one person
+            // thus, restore the unfiltered address book before checking phone number existence
+            model.updateFilteredPersonList(person -> true);
+            Phone targetPhone = (Phone) target;
+            Person personToDelete = find(lastShownList, new PhoneIsKeywordPredicate(targetPhone.value));
+
+            if (personToDelete == null) {
+                throw new CommandException(DeleteCommand.NO_PERSON_WITH_MATCHING_PHONE);
+            }
+
+            model.deletePerson(personToDelete);
+            return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        }
+        default -> {
+            // nothing happens here, all DeletionType cases have been handled
+        }
         }
 
-        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 
     @Override
@@ -57,13 +167,13 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+        return target.equals(otherDeleteCommand.target);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("targetIndex", targetIndex)
+                .add("target", target)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -29,7 +29,7 @@ public class FilterCommand extends Command {
             + "non-unique identifiers and displays the person's full information.\n"
             + "Non-unique identifiers include name, address and tags.\n"
             + "Exact name, tags and address must be provided.\n"
-            + "Users can provide multiple tags at once"
+            + "Users can provide multiple tags at once.\n"
             + "Parameters: [" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_TAG + "TAGS]\n"

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -34,7 +34,7 @@ public class FindCommand extends Command {
             + "or: " + COMMAND_WORD + " " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com";
 
     public static final String TOO_MANY_IDENTIFIERS_SPECIFIED = "Too many attributes specified!\n%1$s";
-    public static final String NOT_UNIQUE_ATTRIBUTE_DETECTED = "A non-unique attribute detected!\n"
+    public static final String NOT_UNIQUE_ATTRIBUTE_DETECTED = "A non-unique attribute is detected!\n"
             + "For non-unique attributes, use 'filter'.\n%1$s";
 
     private final Predicate<Person> predicate;

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -80,6 +80,6 @@ public class ArgumentMultimap {
      * Returns the number of detected prefixes in the argument multimap.
      */
     public int getNumberOfPrefixes() {
-        return argMultimap.size();
+        return argMultimap.size() - 1;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -25,9 +25,6 @@ public class ArgumentTokenizer {
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
-        for (PrefixPosition pp : positions) {
-            System.out.println(">> " + pp);
-        }
         return extractArguments(argsString, positions);
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,10 +1,17 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Phone;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -17,13 +24,40 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
-        } catch (ParseException pe) {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+
+        if (argMultimap.getNumberOfPrefixes() > 1) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(DeleteCommand.TOO_MANY_ATTRIBUTES_SPECIFIED, DeleteCommand.MESSAGE_USAGE));
         }
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()
+                || argMultimap.getValue(PREFIX_ADDRESS).isPresent()
+                || argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            throw new ParseException(
+                    String.format(DeleteCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+            return new DeleteCommand(phone);
+        }
+
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+            return new DeleteCommand(email);
+        }
+
+        try {
+            Integer.parseInt(args.trim());
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), nfe);
+        }
+
+        Index index = ParserUtil.parseIndex(args);
+        return new DeleteCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -33,7 +33,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        if (argMultimap.getNumberOfPrefixes() > 2) {
+        if (argMultimap.getNumberOfPrefixes() > 1) {
             throw new ParseException(
                     String.format(FilterCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FilterCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -9,7 +9,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Email;
 import seedu.address.model.person.EmailIsKeywordPredicate;
+import seedu.address.model.person.Phone;
 import seedu.address.model.person.PhoneIsKeywordPredicate;
 
 /**
@@ -23,19 +25,17 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        if (argMultimap.getNumberOfPrefixes() > 2) {
+        if (argMultimap.getNumberOfPrefixes() > 1) {
             throw new ParseException(
                     String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
+        }
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()
@@ -46,11 +46,13 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            return new FindCommand(new PhoneIsKeywordPredicate(argMultimap.getValue(PREFIX_PHONE).get()));
+            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+            return new FindCommand(new PhoneIsKeywordPredicate(phone.value));
         }
 
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            return new FindCommand(new EmailIsKeywordPredicate(argMultimap.getValue(PREFIX_EMAIL).get()));
+            Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+            return new FindCommand(new EmailIsKeywordPredicate(email.value));
         }
 
         throw new ParseException(

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,13 +1,19 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -17,16 +23,18 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
  * {@code DeleteCommand}.
  */
 public class DeleteCommandTest {
-
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
+    // integration test by index
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -79,34 +87,189 @@ public class DeleteCommandTest {
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
+    // integration test by email
+    @Test
+    public void execute_validEmailUnfilteredList_success() {
+        Email validEmail = ALICE.getEmail();
+        Person personToDelete = ALICE;
+        DeleteCommand deleteCommand = new DeleteCommand(validEmail);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidEmailUnfilteredList_throwsCommandException() {
+        Email validEmail = AMY.getEmail();
+        DeleteCommand deleteCommand = new DeleteCommand(validEmail);
+
+        String expectedMessage = DeleteCommand.NO_PERSON_WITH_MATCHING_EMAIL;
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    // email is in filtered list
+    @Test
+    public void execute_validEmailFilteredList_success() {
+        Person personToDelete = ALICE;
+        Email emailOfPtd = personToDelete.getEmail();
+        DeleteCommand deleteCommand = new DeleteCommand(emailOfPtd);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        // expect the end-result model to show the ORIGINAL list
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        // thus, copy the original model to expectedModel before we filter
+        model.updateFilteredPersonList(person -> person.equals(ALICE));
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    // email is not in filtered list, but exists in unfiltered list
+    @Test
+    public void execute_validEmailNotInFilteredList_success() {
+        Person personToDelete = BENSON;
+        Email emailOfPtd = personToDelete.getEmail();
+        DeleteCommand deleteCommand = new DeleteCommand(emailOfPtd);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        // expect the end-result model to show the ORIGINAL list
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        // thus, copy the original model to expectedModel before we filter
+        model.updateFilteredPersonList(person -> person.equals(ALICE));
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    // integration test by phone
+    @Test
+    public void execute_validPhoneUnfilteredList_success() {
+        Phone validEmail = BENSON.getPhone();
+        Person personToDelete = BENSON;
+        DeleteCommand deleteCommand = new DeleteCommand(validEmail);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPhoneUnfilteredList_throwsCommandException() {
+        Phone validEmail = BOB.getPhone();
+        DeleteCommand deleteCommand = new DeleteCommand(validEmail);
+
+        String expectedMessage = DeleteCommand.NO_PERSON_WITH_MATCHING_PHONE;
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    // phone is in filtered list
+    @Test
+    public void execute_validPhoneFilteredList_success() {
+        Person personToDelete = ALICE;
+        Phone phoneOfPtd = personToDelete.getPhone();
+        DeleteCommand deleteCommand = new DeleteCommand(phoneOfPtd);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        // expect the end-result model to show the ORIGINAL list
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        // thus, copy the original model to expectedModel before we filter
+        model.updateFilteredPersonList(person -> person.equals(ALICE));
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    // phone is not in filtered list, but exists in unfiltered list
+    @Test
+    public void execute_validPhoneNotInFilteredList_success() {
+        Person personToDelete = BENSON;
+        Phone phoneOfPtd = personToDelete.getPhone();
+        DeleteCommand deleteCommand = new DeleteCommand(phoneOfPtd);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        // expect the end-result model to show the ORIGINAL list
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        // thus, copy the original model to expectedModel before we filter
+        model.updateFilteredPersonList(person -> person.equals(ALICE));
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    // other methods
     @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
         DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
 
+        DeleteCommand deleteEmailCommand = new DeleteCommand(CARL.getEmail());
+
+        DeleteCommand deletePhoneCommand = new DeleteCommand(DANIEL.getPhone());
+
         // same object -> returns true
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
 
         // same values -> returns true
         DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
+
+        DeleteCommand deleteEmailCommandCopy = new DeleteCommand(CARL.getEmail());
+        assertEquals(deleteEmailCommand, deleteEmailCommandCopy);
+
+        DeleteCommand deletePhoneCommandCopy = new DeleteCommand(DANIEL.getPhone());
+        assertEquals(deletePhoneCommand, deletePhoneCommandCopy);
 
         // different types -> returns false
-        assertFalse(deleteFirstCommand.equals(1));
+        assertNotEquals(1, deleteFirstCommand);
+        assertNotEquals("Hello, world!", deletePhoneCommand);
 
         // null -> returns false
-        assertFalse(deleteFirstCommand.equals(null));
+        assertNotEquals(null, deleteFirstCommand);
 
         // different person -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
+        assertNotEquals(deleteEmailCommand, deletePhoneCommand);
     }
 
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
-        assertEquals(expected, deleteCommand.toString());
+        DeleteCommand deleteIndexCommand = new DeleteCommand(targetIndex);
+        String expectedForIndex = DeleteCommand.class.getCanonicalName() + "{target=" + targetIndex + "}";
+        assertEquals(expectedForIndex, deleteIndexCommand.toString());
+
+        Phone targetPhone = new Phone("98765432");
+        DeleteCommand deletePhoneCommand = new DeleteCommand(targetPhone);
+        String expectedForPhone = DeleteCommand.class.getCanonicalName() + "{target=" + targetPhone + "}";
+        assertEquals(expectedForPhone, deletePhoneCommand.toString());
+
+        Email targetEmail = new Email("ilovecraftconnect@example.com");
+        DeleteCommand deleteEmailCommand = new DeleteCommand(targetEmail);
+        String expectedForEmail = DeleteCommand.class.getCanonicalName() + "{target=" + targetEmail + "}";
+        assertEquals(expectedForEmail, deleteEmailCommand.toString());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -8,6 +13,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Phone;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -20,13 +27,67 @@ public class DeleteCommandParserTest {
 
     private DeleteCommandParser parser = new DeleteCommandParser();
 
+    // deletion by index
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+    public void parse_validIndex_returnsDeleteCommand() {
+        assertParseSuccess(parser, " 1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_twoAttributes_throwsParseException() {
+        assertParseFailure(parser,
+                " " + PREFIX_PHONE + "12345678 " + PREFIX_EMAIL + "dummy@example.com",
+                String.format(DeleteCommand.TOO_MANY_ATTRIBUTES_SPECIFIED, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_threeAttributes_throwsParseException() {
+        assertParseFailure(parser,
+                " " + PREFIX_PHONE + "12345678 "
+                        + PREFIX_EMAIL + "dummy@example.com "
+                        + PREFIX_NAME + "alex yeoh",
+                String.format(DeleteCommand.TOO_MANY_ATTRIBUTES_SPECIFIED, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_nameAttribute_throwsParseException() {
+        assertParseFailure(parser,
+                " " + PREFIX_NAME + "alex yeoh",
+                String.format(DeleteCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_addressAttribute_throwsParseException() {
+        assertParseFailure(parser,
+                " " + PREFIX_ADDRESS + "420 Craft Avenue, Gotham 123746",
+                String.format(DeleteCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_tagAttribute_throwsParseException() {
+        assertParseFailure(parser,
+                " " + PREFIX_TAG + "colleague",
+                String.format(DeleteCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validPhone_success() {
+        String phone = "12345678";
+        assertParseSuccess(parser,
+                " " + PREFIX_PHONE + phone,
+                new DeleteCommand(new Phone(phone)));
+    }
+
+    @Test
+    public void parse_validEmail_success() {
+        String email = "ilovecraftconnect@example.com";
+        assertParseSuccess(parser,
+                " " + PREFIX_EMAIL + email,
+                new DeleteCommand(new Email(email)));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -27,25 +27,18 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_onlyFindArg_throwsParseException() {
-        assertParseFailure(parser,
-                "find ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-    }
-
-    @Test
     public void parse_argMoreThanOneAttribute_throwsParseException() {
         assertParseFailure(parser,
-                String.format("find %s91237483 %silovecraftconnect@gmail.com", PREFIX_PHONE, PREFIX_EMAIL),
+                String.format(" %s91237483 %silovecraftconnect@gmail.com", PREFIX_PHONE, PREFIX_EMAIL),
                 String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
 
         assertParseFailure(parser,
-                String.format("find %sneil deGrease Tyson %sastrophysicist@nasa.gov %steacher",
+                String.format(" %sneil deGrease Tyson %sastrophysicist@nasa.gov %steacher",
                         PREFIX_NAME, PREFIX_EMAIL, PREFIX_TAG),
                 String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
 
         assertParseFailure(parser,
-                String.format("find %scolleagues %s59 Dummy Street, Gotham %s83582957 %sfriend",
+                String.format(" %scolleagues %s59 Dummy Street, Gotham %s83582957 %sfriend",
                         PREFIX_TAG, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_TAG),
                 String.format(FindCommand.TOO_MANY_IDENTIFIERS_SPECIFIED, FindCommand.MESSAGE_USAGE));
     }
@@ -53,14 +46,14 @@ public class FindCommandParserTest {
     @Test
     public void parse_argContainsName_throwsParseExceptionForNonUniqueAttribute() {
         assertParseFailure(parser,
-                "find " + PREFIX_NAME + "alex yeoh",
+                " " + PREFIX_NAME + "alex yeoh",
                 String.format(FindCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_argContainsAddress_throwsParseExceptionForNonUniqueAttribute() {
         assertParseFailure(parser,
-                "find " + PREFIX_ADDRESS + "420 Craft Avenue, Singapore 572847",
+                " " + PREFIX_ADDRESS + "420 Craft Avenue, Singapore 572847",
                 String.format(FindCommand.NOT_UNIQUE_ATTRIBUTE_DETECTED, FindCommand.MESSAGE_USAGE));
     }
 
@@ -70,12 +63,12 @@ public class FindCommandParserTest {
         // no whitespace
         FindCommand expectedFindCommand =
                 new FindCommand(new EmailIsKeywordPredicate("ilovecraftconnect@gmail.com"));
-        assertParseSuccess(parser, "find " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com", expectedFindCommand);
 
         // trailing whitespace
         expectedFindCommand =
                 new FindCommand(new EmailIsKeywordPredicate("ilovecraftconnect@gmail.com"));
-        assertParseSuccess(parser, "  find    " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com", expectedFindCommand);
+        assertParseSuccess(parser, "      " + PREFIX_EMAIL + "ilovecraftconnect@gmail.com", expectedFindCommand);
     }
 
     @Test
@@ -83,12 +76,12 @@ public class FindCommandParserTest {
         // no whitespace
         FindCommand expectedFindCommand =
                 new FindCommand(new PhoneIsKeywordPredicate("93424353"));
-        assertParseSuccess(parser, "find " + PREFIX_PHONE + "93424353", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_PHONE + "93424353", expectedFindCommand);
 
 
         // trailing whitespace
         expectedFindCommand =
                 new FindCommand(new PhoneIsKeywordPredicate("93424353"));
-        assertParseSuccess(parser, " find  " + PREFIX_PHONE + "93424353", expectedFindCommand);
+        assertParseSuccess(parser, "   " + PREFIX_PHONE + "93424353", expectedFindCommand);
     }
 }


### PR DESCRIPTION
Fixes #39 

The delete command now supports deletion by unique identifiers (phone number and email address)

The deletion behaviour is as follows (in order):
- If empty args (`find`), throws an invalid command error message.
- If more than one attributes specified (`find p/12345678 e/dummy@example.com` ...), throws a too-many-attributes error message.
- If non-unique attributes specified (`find n/alex yeoh` ...), throws a non-unique attribute error message.
- If unique identifier speficied (`find p/12345678` ...), returns a `DeleteCommand` for valid identifier format, propagates `ParserUtil` error otherwise.
- If arg is not an integer (`find dummy` ...), throws an invalid command error message.
- If arg is an integer not within range, propagates `ParserUtil` error.
- Else, return a `DeleteCommand` with index.