### PR TITLE
Change product JAR name to craftconnect.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'craftconnect.jar'
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
NOTE: Finalised for release. Fixes #59 

The product name is changed to craftconnect.jar
Dummy contacts now have tags more related to small businesses in arts and crafts.