### PR TITLE
Used asserts in `EditCommand` class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
 
+run {
+    enableAssertions = true
+}
+
 checkstyle {
     toolVersion = '10.2'
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -65,7 +65,6 @@ public class EditCommand extends Command {
         requireNonNull(editPersonDescriptor);
 
         assert index.getOneBased() > 0 : "Index must be a positive integer";
-        assert editPersonDescriptor.isAnyFieldEdited() : "At least one field must be edited";
 
         this.index = index;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
@@ -181,7 +180,7 @@ public class EditCommand extends Command {
          * A defensive copy of {@code tags} is used internally.
          */
         public EditPersonDescriptor(EditPersonDescriptor toCopy) {
-            assert toCopy != null : "EditPersonDescriptor to copy cannot be null";
+            assert toCopy != null : "EditPersonDescriptor cannot be null";
 
             setName(toCopy.name);
             setPhone(toCopy.phone);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -50,6 +50,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_FIELDS = "Please provide a new value for the fields you want to edit.";
     public static final String MESSAGE_DUPLICATE_PHONE = "This phone number is already being used by: ";
     public static final String MESSAGE_DUPLICATE_EMAIL = "This email is already being used by: ";
 
@@ -85,7 +86,7 @@ public class EditCommand extends Command {
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
         assert editedPerson != null : "Edited person cannot be null";
         if (editedPerson.equals(personToEdit) || !editPersonDescriptor.isAnyFieldEdited()) {
-            throw new CommandException(MESSAGE_NOT_EDITED);
+            throw new CommandException(MESSAGE_DUPLICATE_FIELDS);
         }
         assert !editedPerson.equals(personToEdit) || !editPersonDescriptor.isAnyFieldEdited()
                 : "Person should be different if fields were edited";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -88,8 +88,8 @@ public class EditCommand extends Command {
         if (editedPerson.equals(personToEdit) || !editPersonDescriptor.isAnyFieldEdited()) {
             throw new CommandException(MESSAGE_NOT_EDITED);
         }
-        assert !editedPerson.equals(personToEdit) || !editPersonDescriptor.isAnyFieldEdited() :
-            "Person should be different if fields were edited";
+        assert !editedPerson.equals(personToEdit) || !editPersonDescriptor.isAnyFieldEdited()
+                : "Person should be different if fields were edited";
 
         // Check if contact is being changed and if it's a duplicate
         for (Person person : lastShownList) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -50,7 +50,6 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
     public static final String MESSAGE_DUPLICATE_PHONE = "This phone number is already being used by: ";
     public static final String MESSAGE_DUPLICATE_EMAIL = "This email is already being used by: ";
 
@@ -65,6 +64,9 @@ public class EditCommand extends Command {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
+        assert index.getOneBased() > 0 : "Index must be a positive integer";
+        assert editPersonDescriptor.isAnyFieldEdited() : "At least one field must be edited";
+
         this.index = index;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
     }
@@ -73,16 +75,25 @@ public class EditCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        assert lastShownList != null : "Filtered person list cannot be null";
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+        assert personToEdit != null : "Person to edit cannot be null";
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        assert editedPerson != null : "Edited person cannot be null";
+        if (editedPerson.equals(personToEdit) || !editPersonDescriptor.isAnyFieldEdited()) {
+            throw new CommandException(MESSAGE_NOT_EDITED);
+        }
+        assert !editedPerson.equals(personToEdit) || !editPersonDescriptor.isAnyFieldEdited() :
+            "Person should be different if fields were edited";
 
         // Check if contact is being changed and if it's a duplicate
         for (Person person : lastShownList) {
+            assert person != null : "Person in list cannot be null";
             if (!person.equals(personToEdit)) {
                 // Check for duplicate phone number
                 if (editedPerson.getPhone().equals(person.getPhone())) {
@@ -106,14 +117,26 @@ public class EditCommand extends Command {
      */
     private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
         assert personToEdit != null;
+        assert editPersonDescriptor != null : "EditPersonDescriptor cannot be null";
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
-        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
-        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
-        Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        assert updatedName != null : "Updated name cannot be null";
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
+        assert updatedPhone != null : "Updated phone cannot be null";
+
+        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
+        assert updatedEmail != null : "Updated email cannot be null";
+
+        Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        assert updatedAddress != null : "Updated address cannot be null";
+
+        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        assert updatedTags != null : "Updated tags cannot be null";
+
+        Person newPerson = new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        assert newPerson != null : "New person cannot be null";
+        return newPerson;
     }
 
     @Override
@@ -158,6 +181,8 @@ public class EditCommand extends Command {
          * A defensive copy of {@code tags} is used internally.
          */
         public EditPersonDescriptor(EditPersonDescriptor toCopy) {
+            assert toCopy != null : "EditPersonDescriptor to copy cannot be null";
+
             setName(toCopy.name);
             setPhone(toCopy.phone);
             setEmail(toCopy.email);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -75,7 +75,7 @@ public class EditCommandTest {
     public void execute_noFieldSpecifiedUnfilteredList_failure() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_NOT_EDITED);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_FIELDS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -72,15 +72,10 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    public void execute_noFieldSpecifiedUnfilteredList_failure() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_NOT_EDITED);
     }
 
     @Test


### PR DESCRIPTION
Notable Change:
- EditCommand now shows an error message when editing with all fields being the same as the old fields 
EXAMPLE:
**Person 1**
Name: John
Phone number: 123
1. edit 1 n/john results in a duplicate error message
2. edit 1 p/123 results in a duplicate error message
3. edit 1 n/jack p/123 is allowed
4. edit 1 n/john p/456 is allowed
- Updated test files for the changes above