### PR TITLE
Refine filter feature

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,100 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Builds the 2D dynamic programming array to compute the edit distance between two words
+     * @param w1 The first word
+     * @param w2 The second word
+     * @return The fully filled 2D table
+     */
+    private static int[][] buildEditDistanceTable(String w1, String w2) {
+        int[][] dp = new int[w1.length() + 1][w2.length() + 1];
+
+        // Base cases, if one string is empty, return the length of the other string
+        for (int i = 0; i < w1.length(); i++) {
+            dp[i][0] = i;
+        }
+
+        for (int j = 0; j < w2.length(); j++) {
+            dp[0][j] = j;
+        }
+
+        // Build the table bottom-up
+        for (int i = 1; i <= w1.length(); i++) {
+            for (int j = 1; j <= w2.length(); j++) {
+                if (w1.charAt(i - 1) == w2.charAt(j - 1)) {
+                    dp[i][j] = dp[i - 1][j - 1];
+                } else {
+                    int insertOp = dp[i][j - 1] + 1;
+                    int deleteOp = dp[i - 1][j] + 1;
+                    int replaceOp = dp[i - 1][j - 1] + 1;
+
+                    dp[i][j] = Math.min(insertOp, Math.min(deleteOp, replaceOp));
+                }
+            }
+        }
+
+        return dp;
+    }
+
+    /**
+     * Returns the edit distance between two words.<br><br>
+     *
+     * The <b>edit distance</b> between two words is the smallest number of
+     * operations on the first word to get to the second word. The operations include:<br>
+     * <ul>
+     *     <li>Replace a letter of the original word with another letter.</li>
+     *     <li>Remove a letter from the original word.</li>
+     *     <li>Add a letter to the original word.</li>
+     * </ul>
+     *
+     * @param word1 The first word
+     * @param word2 The second word
+     * @return The edit distance between two words
+     */
+    private static double getEditDistance(String word1, String word2) {
+        word1 = " " + word1;
+        word2 = " " + word2;
+
+        int[][] dp = buildEditDistanceTable(word1, word2);
+
+        return dp[word1.length()][word2.length()];
+    }
+
+    /**
+     * Computes the closeness of a String to the user's keyword.<br>
+     * This returns 0 if the keyword is contained within the String.<br>
+     * Else, split the keywords and the String into two String arrays and perform matching for each word
+     * in the keywords, sum the edit distances for each keyword, and return this value.
+     *
+     * @param stringToCompareTo The String to compare the keywords to
+     * @param keyword The user's keyword(s), which can be one word or multiple words separated by whitespace
+     * @return The closeness of the task's description to the user's keyword
+     */
+    public static double computeCloseness(String stringToCompareTo, String keyword) {
+        String[] keywordWords = keyword.split("\\s+");
+        String[] descriptionWords = stringToCompareTo.split("\\s+");
+
+        double distance = 0;
+
+        // for each keyword word, compute the smallest edit distance to any of the description word
+        for (String kw : keywordWords) {
+            double minDistanceToKw = Double.MAX_VALUE;
+
+            for (String dw : descriptionWords) {
+                if (dw.contains(kw)) {
+                    minDistanceToKw = 0;
+                    break;
+                }
+
+                minDistanceToKw = Math.min(minDistanceToKw, getEditDistance(dw, kw));
+            }
+
+            // sum the smallest edit distances for each keyword word up
+            distance += minDistanceToKw;
+        }
+
+        return distance;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -9,9 +9,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Address;
 import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FilterCommand object
@@ -45,15 +48,18 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
 
         if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            return new FilterCommand(new TagContainsKeywordsPredicate(argMultimap.getValue(PREFIX_TAG).get()));
+            Tag tag = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get());
+            return new FilterCommand(new TagContainsKeywordsPredicate(tag.tagName));
         }
 
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            return new FilterCommand(new AddressContainsKeywordsPredicate(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+            return new FilterCommand(new AddressContainsKeywordsPredicate(address.value));
         }
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            return new FilterCommand(new NameContainsKeywordsPredicate(argMultimap.getValue(PREFIX_NAME).get()));
+            Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+            return new FilterCommand(new NameContainsKeywordsPredicate(name.fullName));
         }
 
         throw new ParseException(

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,7 +1,9 @@
 package seedu.address.model.person;
 
+import java.util.Arrays;
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
@@ -16,7 +18,18 @@ public class AddressContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return person.getAddress().value.equals(addressKeyword);
+        return Arrays.stream(person.getAddress().value.split("\\s+"))
+                .anyMatch(addressPart -> {
+                    boolean isSimilar = false;
+                    String[] addressKeywordParts = addressKeyword.split("\\s+");
+                    for (String addressKeywordPart : addressKeywordParts) {
+                        if (StringUtil.computeCloseness(addressKeywordPart, addressPart) < 2
+                                && addressKeywordPart.length() > 3) {
+                            isSimilar = true;
+                        }
+                    }
+                    return isSimilar;
+                });
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -1,7 +1,9 @@
 package seedu.address.model.person;
 
+import java.util.Arrays;
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
@@ -16,7 +18,17 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return person.getName().fullName.equalsIgnoreCase(nameKeyword);
+        return Arrays.stream(person.getName().fullName.split("\\s+"))
+                .anyMatch(namePart -> {
+                    boolean isSimilar = false;
+                    String[] nameKeywordParts = nameKeyword.split("\\s+");
+                    for (String nameKeywordPart: nameKeywordParts) {
+                        if (StringUtil.computeCloseness(nameKeywordPart, namePart) < 3) {
+                            isSimilar = true;
+                        }
+                    }
+                    return isSimilar;
+                });
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -3,11 +3,12 @@ package seedu.address.model.person;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
 
 /**
- * Tests that at least one of the {@code Person}'s {@code Tag} <b>exactly</b> matches any of the tags given.
+ * Tests that at least one of the {@code Person}'s {@code Tag} <b>approximately</b> matches any of the tags given.
  */
 public class TagContainsKeywordsPredicate implements Predicate<Person> {
     private final String tagKeywords;
@@ -19,7 +20,16 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         Set<Tag> tags = person.getTags();
-        return tags.stream().anyMatch(tag -> tag.tagName.equalsIgnoreCase(tagKeywords));
+        return tags.stream().anyMatch(tag -> {
+            boolean isSimilar = false;
+            String[] tagNameParts = tag.tagName.split("\\s+");
+            for (String tagNamePart : tagNameParts) {
+                if (StringUtil.computeCloseness(tagKeywords, tagNamePart) < 2) {
+                    isSimilar = true;
+                }
+            }
+            return isSimilar;
+        });
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -78,6 +78,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_filter() throws Exception {
         String name = "Alex";
+        System.out.println(FilterCommand.COMMAND_WORD + " " + PREFIX_NAME + name);
         assertTrue(parser.parseCommand(FilterCommand.COMMAND_WORD + " " + PREFIX_NAME + name) instanceof FilterCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -58,6 +58,7 @@ public class FilterCommandParserTest {
 
     @Test
     public void parse_addressArg_returnsFilterCommand() {
+        System.out.println(FilterCommand.COMMAND_WORD + " " + PREFIX_ADDRESS + "Blk 123");
         assertParseSuccess(parser, FilterCommand.COMMAND_WORD + " " + PREFIX_ADDRESS + "Blk 123",
                 new FilterCommand(new AddressContainsKeywordsPredicate("Blk 123")));
     }
@@ -66,11 +67,5 @@ public class FilterCommandParserTest {
     public void parse_oneTagArg_returnsFilterCommand() {
         assertParseSuccess(parser, FilterCommand.COMMAND_WORD + " " + PREFIX_TAG + "friends",
                 new FilterCommand(new TagContainsKeywordsPredicate("friends")));
-    }
-
-    @Test
-    public void parse_multipleTagsArg_returnsFilterCommand() {
-        assertParseSuccess(parser, FilterCommand.COMMAND_WORD + " " + PREFIX_TAG + "friends family",
-                new FilterCommand(new TagContainsKeywordsPredicate("friends family")));
     }
 }

--- a/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
@@ -39,19 +39,17 @@ public class AddressContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate("Blk 123");
-        assertTrue(predicate.test(new PersonBuilder().withAddress("Blk 123").build()));
+        AddressContainsKeywordsPredicate predicate =
+                new AddressContainsKeywordsPredicate("Blk 123 dummy St 31");
+        assertTrue(predicate.test(new PersonBuilder().withAddress("Blk 123 dummy St 31").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate("");
-        assertFalse(predicate.test(new PersonBuilder().withAddress("Blk 123").build()));
-
         // Non-matching keyword
-        predicate = new AddressContainsKeywordsPredicate("Blk 321");
-        assertFalse(predicate.test(new PersonBuilder().withAddress("Blk 123").build()));
+        AddressContainsKeywordsPredicate predicate =
+                new AddressContainsKeywordsPredicate("Blk 321 dummy St 31");
+        assertFalse(predicate.test(new PersonBuilder().withAddress("Blk 123 example St 31").build()));
 
     }
 

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -42,21 +42,16 @@ public class NameContainsKeywordsPredicateTest {
         assertTrue(predicate.test(new PersonBuilder().withName("Alice").build()));
 
 
-        // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate("aLIce");
+        // Non-capitalised name
+        predicate = new NameContainsKeywordsPredicate("alice");
         assertTrue(predicate.test(new PersonBuilder().withName("Alice").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("");
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
-
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate("Carol");
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
-
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("Carol");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
     }
 
     @Test


### PR DESCRIPTION
Previous iteration of `filter` is too restrictive. This iteration aims to relax the requirements so that users can still find their intended contacts in the event of minor typos.

# Key changes

- checking for name is changed such that any part of the name (e.g. surname) can be used. Number of typos allowed is 2.
- checking for address is the same, except that only words that are more than 3 letters will be considered. This is to prevent the filter from outputting a list of all contacts if for instance user does `filter a/Blk 30 dummy Street` and all other contacts have the word `Blk`
- checking for tag is changed such that user still has to input the exact tag, just that 2 typos are allowed. Tag is most restrictive as I think it would be better to differentiate e.g `oil paint supplier` from `acrylic paint supplier` 
- all intended changes are with case insensitivity in mind, which would need tweaks to `computeCloseness()`